### PR TITLE
git: accept explicit commit hash for git context

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -30,6 +30,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-git/go-git/v5"
+	gitConfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/pkg/errors"
@@ -205,22 +209,54 @@ func TestRun(t *testing.T) {
 	}
 }
 
-func getGitRepo() string {
+func findSHA(ref plumbing.ReferenceName, refs []*plumbing.Reference) (string, error) {
+	for _, ref2 := range refs {
+		if ref.String() == ref2.Name().String() {
+			return ref2.Hash().String(), nil
+		}
+	}
+	return "", errors.New("no ref found")
+}
+
+// getBranchSHA get a SHA commit hash for the given repo url and branch ref name.
+func getBranchSHA(t *testing.T, url, branch string) string {
+	repo := "https://" + url
+	c := &gitConfig.RemoteConfig{URLs: []string{repo}}
+	remote := git.NewRemote(memory.NewStorage(), c)
+	refs, err := remote.List(&git.ListOptions{})
+	if err != nil {
+		t.Fatalf("list remote %s#%s: %s", repo, branch, err)
+	}
+	commit, err := findSHA(plumbing.NewBranchReferenceName(branch), refs)
+	if err != nil {
+		t.Fatalf("findSHA %s#%s: %s", repo, branch, err)
+	}
+	return commit
+}
+
+func getGitRepo(t *testing.T, explicit bool) string {
 	var branch, repoSlug string
-	if os.Getenv("TRAVIS_PULL_REQUEST") != "" {
+	if _, ok := os.LookupEnv("TRAVIS_PULL_REQUEST"); ok {
 		branch = "master"
 		repoSlug = os.Getenv("TRAVIS_REPO_SLUG")
 		log.Printf("Travis CI Pull request source repo: %s branch: %s\n", repoSlug, branch)
-	} else {
+	} else if _, ok := os.LookupEnv("TRAVIS_BRANCH"); ok {
 		branch = os.Getenv("TRAVIS_BRANCH")
 		repoSlug = os.Getenv("TRAVIS_REPO_SLUG")
 		log.Printf("Travis CI repo: %s branch: %s\n", repoSlug, branch)
+	} else {
+		branch = "master"
+		repoSlug = "GoogleContainerTools/kaniko"
+	}
+	url := "github.com/" + repoSlug
+	if explicit {
+		return url + "#" + getBranchSHA(t, url, branch)
 	}
 	return "github.com/" + repoSlug + "#refs/heads/" + branch
 }
 
-func TestGitBuildcontext(t *testing.T) {
-	repo := getGitRepo()
+func testGitBuildcontextHelper(t *testing.T, repo string) {
+	t.Log("testGitBuildcontextHelper repo", repo)
 	dockerfile := fmt.Sprintf("%s/%s/Dockerfile_test_run_2", integrationPath, dockerfilesPath)
 
 	// Build with docker
@@ -257,8 +293,18 @@ func TestGitBuildcontext(t *testing.T) {
 	checkContainerDiffOutput(t, diff, expected)
 }
 
+func TestGitBuildcontext(t *testing.T) {
+	repo := getGitRepo(t, false)
+	testGitBuildcontextHelper(t, repo)
+}
+
+func TestGitBuildcontextExplicitCommit(t *testing.T) {
+	repo := getGitRepo(t, true)
+	testGitBuildcontextHelper(t, repo)
+}
+
 func TestGitBuildcontextSubPath(t *testing.T) {
-	repo := getGitRepo()
+	repo := getGitRepo(t, false)
 	dockerfile := "Dockerfile_test_run_2"
 
 	// Build with docker
@@ -267,8 +313,8 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 		append([]string{
 			"build",
 			"-t", dockerImage,
-			"-f", dockerfile,
-			repo + ":" + filepath.Join(integrationPath, dockerfilesPath),
+			"-f", filepath.Join(integrationPath, dockerfilesPath, dockerfile),
+			repo,
 		})...)
 	out, err := RunCommandWithoutTest(dockerCmd)
 	if err != nil {
@@ -302,7 +348,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 }
 
 func TestBuildViaRegistryMirrors(t *testing.T) {
-	repo := getGitRepo()
+	repo := getGitRepo(t, false)
 	dockerfile := fmt.Sprintf("%s/%s/Dockerfile_registry_mirror", integrationPath, dockerfilesPath)
 
 	// Build with docker
@@ -342,7 +388,7 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 }
 
 func TestBuildWithLabels(t *testing.T) {
-	repo := getGitRepo()
+	repo := getGitRepo(t, false)
 	dockerfile := fmt.Sprintf("%s/%s/Dockerfile_test_label", integrationPath, dockerfilesPath)
 
 	testLabel := "mylabel=myvalue"
@@ -385,7 +431,7 @@ func TestBuildWithLabels(t *testing.T) {
 }
 
 func TestBuildWithHTTPError(t *testing.T) {
-	repo := getGitRepo()
+	repo := getGitRepo(t, false)
 	dockerfile := fmt.Sprintf("%s/%s/Dockerfile_test_add_404", integrationPath, dockerfilesPath)
 
 	// Build with docker


### PR DESCRIPTION
When checking out code from non-github repositories, the typical
assumptions may not be valid, e.g. that the only interesting
non-branch commits have ref names starting with refs/pull. A specific
example is fetching an un-merged commit from a gerrit repository by
commit hash.

This change just looks at the second part of the git context path and
checks if it's a SHA commit hash, and if so, will fetch and check out
this commit after cloning the repository.

Sample context argument:

    https://github.repo/project#e1772f228e06d15facdf175e5385e265b57068c0

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #<issue number> _in case of a bug fix, this should point to a bug and any other related issue(s)_

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
